### PR TITLE
feat: add package for asset images #317

### DIFF
--- a/lib/src/assert_image.dart
+++ b/lib/src/assert_image.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_img/src/shapes.dart';
 import 'package:flutter_svg/svg.dart';
@@ -10,6 +11,7 @@ class AssetImageHandler extends StatelessWidget {
   const AssetImageHandler(
     this.src, {
     super.key,
+    this.package,
     this.height,
     this.width,
     this.shape,
@@ -23,6 +25,10 @@ class AssetImageHandler extends StatelessWidget {
 
   /// `src` is the asset image source for [AssetImageHandler].
   final String src;
+
+  /// `package` is the name of the package where the image is located.
+  /// It's only used for asset images
+  final String? package;
 
   /// `height` explicitly set image height. you can pass a
   /// height value or it will adjust the height based on image
@@ -101,6 +107,7 @@ class AssetImageHandler extends StatelessWidget {
           backgroundColor: backgroundColor,
           child: Image.asset(
             src,
+            package: package,
             height: height ?? calHeight,
             width: width ?? calWidth,
           ),
@@ -119,7 +126,10 @@ class AssetImageHandler extends StatelessWidget {
         margin: margin,
         colorFilter: colorFilter,
         borderRadius: borderRadius,
-        child: SvgPicture.asset(src),
+        child: SvgPicture.asset(
+          src,
+          package: package,
+        ),
       );
     }
     return ImageShape(

--- a/lib/src/flutter_img.dart
+++ b/lib/src/flutter_img.dart
@@ -22,6 +22,7 @@ class Img extends StatelessWidget {
   const Img(
     this.src, {
     super.key,
+    this.package,
     this.height,
     this.blurHash,
     this.placeholder,
@@ -40,6 +41,10 @@ class Img extends StatelessWidget {
   /// `src` is the image source for [Img].
   /// `src` string can be a asset or network.
   final String src;
+
+  /// `package` is the name of the package where the image is located.
+  /// It's only used for asset images
+  final String? package;
 
   /// `height` explicitly set image height. you can pass a
   /// height value or it will adjust the height based on image
@@ -113,6 +118,7 @@ class Img extends StatelessWidget {
     } else {
       return AssetImageHandler(
         src,
+        package: package,
         width: width,
         height: height,
         colorFilter: colorFilter,


### PR DESCRIPTION
Add the possibility to specify a package name for asset images.

See [issue](https://github.com/ishafiul/flutter_img/issues/17) for more details about changes. 

## Status

READY

## Description

Add `package` property in `Img` and `AssetImageHandler`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
